### PR TITLE
[eclipse/xtext#1561] removed superfluous timestamps() config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,6 @@ spec:
     buildDiscarder(logRotator(numToKeepStr:'15'))
     disableConcurrentBuilds()
     timeout(time: 45, unit: 'MINUTES')
-    timestamps()
   }
 
   // https://jenkins.io/doc/book/pipeline/syntax/#triggers


### PR DESCRIPTION
[eclipse/xtext#1561] removed superfluous timestamps() config
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>